### PR TITLE
Add root_path for nested wiki files

### DIFF
--- a/default.html
+++ b/default.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<link rel="Stylesheet" type="text/css" href="../vimwiki-assets/markdown.css" />
-	<link rel="Stylesheet" type="text/css" href="../vimwiki-assets/github.css" />
+	<link rel="Stylesheet" type="text/css" href="%root_path%../vimwiki-assets/markdown.css" />
+	<link rel="Stylesheet" type="text/css" href="%root_path%../vimwiki-assets/github.css" />
 	<title>%title%</title>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 </head>
@@ -10,8 +10,8 @@
 	<div class="content">
 		%content%
 	</div>
-<script type="text/javascript" src="../vimwiki-assets/highlight.pack.js"></script>
-<script type="text/javascript" src="../vimwiki-assets/zepto.min.js"></script>
+<script type="text/javascript" src="%root_path%../vimwiki-assets/highlight.pack.js"></script>
+<script type="text/javascript" src="%root_path%../vimwiki-assets/zepto.min.js"></script>
 <script type="text/javascript">
 $('pre').each(function(index,item){ $(item).html('<code>'+$(item).html()+'</code>'); });
 hljs.initHighlightingOnLoad();


### PR DESCRIPTION
This fixes an issue for nested wiki files (diary for example). root_path is replaced by enough '../../' to get to the root of the export folder.